### PR TITLE
Apply rotation transformation on marker drag.

### DIFF
--- a/leaflet.rotatedMarker.js
+++ b/leaflet.rotatedMarker.js
@@ -2,6 +2,7 @@
     // save these original methods before they are overwritten
     var proto_initIcon = L.Marker.prototype._initIcon;
     var proto_setPos = L.Marker.prototype._setPos;
+    var proto_onDrag = L.Handler.MarkerDrag.prototype._onDrag;
 
     var oldIE = (L.DomUtil.TRANSFORM === 'msTransform');
 
@@ -22,7 +23,10 @@
 
         _setPos: function (pos) {
             proto_setPos.call(this, pos);
+            this._applyRotation();
+        },
 
+        _applyRotation: function () {
             if(this.options.rotationAngle) {
                 this._icon.style[L.DomUtil.TRANSFORM+'Origin'] = this.options.rotationOrigin;
 
@@ -48,4 +52,11 @@
             return this;
         }
     });
+
+    L.Handler.MarkerDrag.include({
+        _onDrag: function (e) {
+            proto_onDrag.call(this, e);
+            this._marker._applyRotation();
+        }
+    })
 })();


### PR DESCRIPTION
Potential fix for issue #9 

During marker drag events the _setPos method is bypassed in favour of
setting the marker._latlng property directly. In order to account for
this the rotation must be applied after the MarkerDrag._onDrag method.
This is called repeatedly during the movement.