### PR TITLE
Docs(README): add link to live demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Leaflet Rotated Marker
 ===
 
-Enables rotation of marker icons in Leaflet.
+Enables rotation of marker icons in Leaflet. [Demo](http://bbecquet.github.io/Leaflet.RotatedMarker/example.html)
 
 Compatible with versions 0.7.* and 1.* of Leaflet. Doesn't work on IE < 9.
 


### PR DESCRIPTION
Hi,

Thank you for your plugin!

This simple documentation PR adds a link to your _already configured_ live demo page, directly on the home README page.

With this, visitors can have a quick glance at what the plugin is doing.