### PR TITLE
Switch example to HTTPS

### DIFF
--- a/example.html
+++ b/example.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
@@ -6,14 +6,14 @@
 
     <title>Leaflet rotated marker example</title>
 
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v1.1.0/leaflet.css" />
+    <link rel="stylesheet" href="https://cdn.leafletjs.com/leaflet/v1.1.0/leaflet.css" />
     <style>
         * { margin: 0; padding: 0; }
         html, body { height: 100%; }
         #map { width:100%; height:100%; }
     </style>
 
-    <script src="http://cdn.leafletjs.com/leaflet/v1.1.0/leaflet-src.js"></script>
+    <script src="https://cdn.leafletjs.com/leaflet/v1.1.0/leaflet-src.js"></script>
     <script src="leaflet.rotatedMarker.js"></script>
     <script>
         window.onload = function() {
@@ -21,7 +21,7 @@
                 center: [48.8631169, 2.3708919],
                 zoom: 8,
                 layers: [
-                    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
                     })
                 ]


### PR DESCRIPTION
The demo is currently broken because GH pages moved to HTTPS some time ago. This PR switches all CDN and the tileserver to use HTTPS to avoid mixed content error on GH pages