### PR TITLE
change cdn to unpkg

### DIFF
--- a/example.html
+++ b/example.html
@@ -6,14 +6,14 @@
 
     <title>Leaflet rotated marker example</title>
 
-    <link rel="stylesheet" href="https://cdn.leafletjs.com/leaflet/v1.1.0/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />
     <style>
         * { margin: 0; padding: 0; }
         html, body { height: 100%; }
         #map { width:100%; height:100%; }
     </style>
 
-    <script src="https://cdn.leafletjs.com/leaflet/v1.1.0/leaflet-src.js"></script>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
     <script src="leaflet.rotatedMarker.js"></script>
     <script>
         window.onload = function() {


### PR DESCRIPTION
unpkg currently recommended on Leaflet site.  cdn.leafletjs.com fails with SSL error, breaking example.  This also bumps to latest Leaflet version.  See https://danroot.github.io/Leaflet.RotatedMarker/example.html for demonstration of this change working.