### PR TITLE
Add null-check for marker in applyRotation

### DIFF
--- a/leaflet.rotatedMarker.js
+++ b/leaflet.rotatedMarker.js
@@ -29,7 +29,7 @@
         },
 
         _applyRotation: function () {
-            if(this.options.rotationAngle) {
+            if(this._icon && this.options.rotationAngle) {
                 this._icon.style[L.DomUtil.TRANSFORM+'Origin'] = this.options.rotationOrigin;
 
                 if(oldIE) {


### PR DESCRIPTION
I've added null-safety to applyRotation function.

I am using this plugin in a react app along with [leaflet.markercluster](https://www.npmjs.com/package/leaflet.markercluster) and apply rotation to markers inside cluster. I've a menu in the app which filters the markers.
For one edge case, where several markers inside marker cluster are at same position, applying filter crashes the app with error reading `this._icon`. So, I've added a null-check by adding it inside if condition.

![Screenshot 2021-12-17 at 5 26 30 PM](https://user-images.githubusercontent.com/86237581/146541402-95479429-3f86-43af-b72e-645d57232123.png)

@bbecquet 