### PR TITLE
Icon anchor should be interpreted as L.Point

### DIFF
--- a/example.html
+++ b/example.html
@@ -6,14 +6,18 @@
 
     <title>Leaflet rotated marker example</title>
 
-    <link rel="stylesheet" href="https://cdn.leafletjs.com/leaflet/v1.1.0/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+        crossorigin=""/>
     <style>
         * { margin: 0; padding: 0; }
         html, body { height: 100%; }
         #map { width:100%; height:100%; }
     </style>
 
-    <script src="https://cdn.leafletjs.com/leaflet/v1.1.0/leaflet-src.js"></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+        crossorigin=""></script>
     <script src="leaflet.rotatedMarker.js"></script>
     <script>
         window.onload = function() {

--- a/leaflet.rotatedMarker.js
+++ b/leaflet.rotatedMarker.js
@@ -9,7 +9,8 @@
         var iconOptions = this.options.icon && this.options.icon.options;
         var iconAnchor = iconOptions && this.options.icon.options.iconAnchor;
         if (iconAnchor) {
-            iconAnchor = (iconAnchor[0] + 'px ' + iconAnchor[1] + 'px');
+            iconAnchor = L.point(iconAnchor);
+            iconAnchor = (iconAnchor.x + 'px ' + iconAnchor.y + 'px');
         }
         this.options.rotationOrigin = this.options.rotationOrigin || iconAnchor || 'center bottom' ;
         this.options.rotationAngle = this.options.rotationAngle || 0;


### PR DESCRIPTION
The Leaflet documentation defines the property `iconAnchor` of an icon as `L.Point`, so rotated marker should also accept `{x: 10, y: 20}` and not only `[10, 20]`. I write a little fix for this nice plugin.

PS: I also updated the example to the least Leaflet version 1.9.4.